### PR TITLE
stop riddler from being tongue-tied over mon names

### DIFF
--- a/include/string_util.h
+++ b/include/string_util.h
@@ -47,5 +47,6 @@ void StripExtCtrlCodes(u8 *str);
 u8 *StringCopyUppercase(u8 *dest, const u8 *src);
 s32 DoesStringContainMonName(const u8 *string, const u8 *monName);
 void ToLowerCase(u8 *string);
+u8 *StringCopyCensorWord(u8 *dest, const u8 *src, u8 wordStartIndex, u8 wordLength);
 
 #endif // GUARD_STRING_UTIL_H

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2081,18 +2081,18 @@ bool8 ScrCmd_randomdexmessage(struct ScriptContext *ctx)
 {
     u16 species = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
     struct WindowTemplate winTemplate;
-
-    do
-    {
-        species = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
-
-    } while (DoesStringContainMonName(GetSpeciesPokedexDescription(species), GetSpeciesName(species)) != -1);
     
     const u8 *speciesName = GetSpeciesName(species);
     const u8 *randomDexDesc = GetSpeciesPokedexDescription(species);
     StringCopy(gStringVar1, speciesName);
 
-    StringExpandPlaceholders(gStringVar4, randomDexDesc);
+    // Calculates the start of the mon's name if present. If not present, returns -1.
+    s8 monNameStartIndex = DoesStringContainMonName(randomDexDesc, speciesName);
+    if (monNameStartIndex != -1)
+        StringCopyCensorWord(gStringVar4, randomDexDesc, monNameStartIndex, StringLength(speciesName));
+    else
+        StringCopy(gStringVar4, randomDexDesc);
+
     winTemplate = CreateWindowTemplate(0, 1, 5, 28, 9, 0xF, 0x1);
     sRandomDexWindowId = AddWindow(&winTemplate);
     LoadUserWindowBorderGfx(sRandomDexWindowId, 0x214, BG_PLTT_ID(14));

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -918,3 +918,35 @@ void ToLowerCase(u8 *string)
         string++;
     }
 }
+
+u8 *StringCopyCensorWord(u8 *dest, const u8 *src, u8 wordStartIndex, u8 wordLength)
+{
+    u8 index = 0;
+
+    // Copy characters until the beginning of the censored word.
+    while (*src != EOS)
+    {
+        if (index == wordStartIndex)
+        {
+            // Insert three ellipses instead of the censored word.
+            *dest++ = 0xB0; // First ellipsis
+            *dest++ = 0xB0; // Second ellipsis
+            *dest++ = 0xB0; // Third ellipsis
+
+            // Skip the censored word.
+            src += wordLength;
+            index += wordLength;
+        }
+        else
+        {
+            // Copy characters normally.
+            *dest++ = *src++;
+            index++;
+        }
+    }
+
+    // Null-terminate the destination string.
+    *dest = EOS;
+
+    return dest;
+}


### PR DESCRIPTION
Increases the riddlers yapping power by allowing him to speak dex entries with mons names in them. When doing so, he censor's the mon's name with three elipsis.

Adds a new function `CopyStringCensorWord` which accepts a starting position and string length and then just- doesn't copy over that section... this simple solution took me longer to conceptualise than it did to code (like 30 seconds tops).

Three elipsis' can be changed in the function to whatever you want.