### PR TITLE
stops universal collapse when battling bug trainer

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1171,7 +1171,7 @@ void SetMapVarsToTrainer(void)
         gSelectedObjectEvent = GetObjectEventIdByLocalIdAndMap(sTrainerObjectEventLocalId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup);
     }
     if (gTrainerBattleOpponent_A != 0) {
-        gSpeakerName = gTrainers[gTrainerBattleOpponent_A]->trainerName;
+        gSpeakerName = GetTrainerNameFromId(gTrainerBattleOpponent_A);
     }
 }
 
@@ -1645,11 +1645,11 @@ static const u8 *ReturnEmptyStringIfNull(const u8 *string)
 static const u8 *GetIntroSpeechOfApproachingTrainer(void)
 {
     if (gApproachingTrainerId == 0) {
-        gSpeakerName = gTrainers[gTrainerBattleOpponent_A]->trainerName;
+        gSpeakerName = GetTrainerNameFromId(gTrainerBattleOpponent_A);
         return ReturnEmptyStringIfNull(sTrainerAIntroSpeech);
     }
     else {
-        gSpeakerName = gTrainers[gTrainerBattleOpponent_B]->trainerName;
+        gSpeakerName = GetTrainerNameFromId(gTrainerBattleOpponent_B);
         return ReturnEmptyStringIfNull(sTrainerBIntroSpeech);
     }
 }


### PR DESCRIPTION
because of the addition of difficulty turning `gTrainers` into a 2D array, the code at the `GetIntroSpeechOfApproachingTrainer` was trying to access invalid data as the trainer name (and a lot of it).

Fixed by using the `GetTrainerNameFromId` utility.