### PR TITLE
fixes an issue in how I was accessing a field

### DIFF
--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -19,7 +19,7 @@
 	.4byte \script
 	.endm
 
-	.macro object_event index:req, gfx:req, x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req, deadnight=0, earlymorning=0, morning=0, lunchtime=0, afternoon=0, evening=0, night=0
+	.macro object_event index:req, gfx:req, x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req, deadnight=0, earlymorning=0, morning=0, lunchtime=0, noontime=0, evening=0, night=0
 	.byte \index
 	.2byte \gfx
 	.byte OBJ_KIND_NORMAL
@@ -31,7 +31,7 @@
 		.error "movementRangeX has a bitfield of 4 bytes, so values over 15 will overflow. Use a custom script for item balls that should give the player more than 15 items."
 	.endif
 	.byte ((\y_radius << 4) | \x_radius)
-    .byte ((\night << 6) | (\evening << 5) | (\afternoon << 4) | (\lunchtime << 3) | (\morning << 2) | (\earlymorning << 1) | (\deadnight << 0))
+    .byte ((\night << 6) | (\evening << 5) | (\noontime << 4) | (\lunchtime << 3) | (\morning << 2) | (\earlymorning << 1) | (\deadnight << 0))
 	.2byte \trainer_type
 	.2byte \sight_radius_tree_etc
 	.4byte \script

--- a/include/global.fieldmap.h
+++ b/include/global.fieldmap.h
@@ -74,16 +74,23 @@ struct __attribute__((packed, aligned(4))) ObjectEventTemplate
     /*0x06*/ s16 y;
     /*0x08*/ u8 elevation;
     /*0x09*/ u8 movementType;
-    /*0x0A*/ u16 movementRangeX:4;
-             u16 movementRangeY:4;
-             u16 visDeadNight:1;
-             u16 visEarlyMorning:1;
-             u16 visMorning:1;
-             u16 visLunchtime:1;
-             u16 visAfternoon:1;
-             u16 visEvening:1;
-             u16 visNight:1;
-             u16 unused:1; // Requires modification of areAnyVisibilityFlagsSet to use
+    /*0x0A*/ u8 movementRangeX:4;
+             u8 movementRangeY:4;
+
+    /*0x0B*/ union {
+                struct {
+                    u8 deadnight:1;
+                    u8 earlymorning:1;
+                    u8 morning:1;
+                    u8 lunchtime:1;
+                    u8 noontime:1;
+                    u8 evening:1;
+                    u8 night:1;
+                    u8 unused:1; // Requires modification of areAnyTimeVisibilityFieldsSet to use
+                } bits;
+                u8 raw;
+             } timeVisibility;
+
     /*0x0C*/ u16 trainerType;
     /*0x0E*/ u16 trainerRange_berryTreeId;
     /*0x10*/ const u8 *script;

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1812,31 +1812,31 @@ static void TrySpawnObjectEventTemplateBasedOnSchedule(const struct ObjectEventT
   switch(timeOfDay)
   {
     case TIME_DEAD_NIGHT:
-      if (objectEventTemplate->visDeadNight)
+      if (objectEventTemplate->timeVisibility.bits.deadnight)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_EARLY_MORNING:
-      if (objectEventTemplate->visEarlyMorning)
+      if (objectEventTemplate->timeVisibility.bits.earlymorning)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_MORNING:
-      if (objectEventTemplate->visMorning)
+      if (objectEventTemplate->timeVisibility.bits.morning)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_LUNCHTIME:
-      if (objectEventTemplate->visLunchtime)
+      if (objectEventTemplate->timeVisibility.bits.lunchtime)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_NOONTIME:
-      if (objectEventTemplate->visAfternoon)
+      if (objectEventTemplate->timeVisibility.bits.noontime)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_EVENING:
-      if (objectEventTemplate->visEvening)
+      if (objectEventTemplate->timeVisibility.bits.evening)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
     case TIME_NIGHT:
-      if (objectEventTemplate->visNight)
+      if (objectEventTemplate->timeVisibility.bits.night)
         TrySpawnObjectEventTemplate(objectEventTemplate, mapNum, mapGroup, cameraX, cameraY);
       break;
   }
@@ -2684,13 +2684,6 @@ void GetFollowerAction(struct ScriptContext *ctx) // Essentially a big switch fo
                         gFollowerBasicMessages[emotion].script);
 }
 
-// Since visibility fields are packed into the field beginning with movementRangeX, 
-// we check that field against a specific mask (only check the last 8 bits).
-static inline bool32 areAnyTimeVisibilityFieldsSet(const struct ObjectEventTemplate* objectEvent) 
-{
-    return (objectEvent->movementRangeX & 0xFF) != 0;
-}
-
 void TrySpawnObjectEvents(s16 cameraX, s16 cameraY)
 {
     u8 i;
@@ -2723,7 +2716,7 @@ void TrySpawnObjectEvents(s16 cameraX, s16 cameraY)
 
             if (top <= npcY && bottom >= npcY && left <= npcX && right >= npcX)
             {
-                if (areAnyTimeVisibilityFieldsSet(template))
+                if (template->timeVisibility.raw)
                     TrySpawnObjectEventTemplateBasedOnSchedule(template, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, cameraX, cameraY, timeOfDay);
                 else
                     TrySpawnObjectEventTemplate(template, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, cameraX, cameraY);


### PR DESCRIPTION
Uses a union so I can access the entire field at once within the check.

Also renamed all instances of time references with the ones used by Ruby, with precise capitalisation for clarity.

**Untested** _(but I'm pretty sure it should work)_