### PR TITLE
Implement Citrus Bolt's mon color variation

### DIFF
--- a/include/decompress.h
+++ b/include/decompress.h
@@ -28,4 +28,8 @@ void LoadSpecialPokePic(void *dest, s32 species, u32 personality, bool8 isFrontP
 
 u32 GetDecompressedDataSize(const u32 *ptr);
 
+u8 LoadUniqueSpritePalette(const struct SpritePalette *palette, u16 species, u32 personality, bool8 isShiny);
+u32 LoadCompressedUniqueSpritePalette(const struct CompressedSpritePalette *src, u16 species, u32 personality, bool8 isShiny);
+u32 LoadCompressedUniqueSpritePaletteWithTag(const u32 *pal, u16 tag, u16 species, u32 personality, bool8 isShiny);
+
 #endif // GUARD_DECOMPRESS_H

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -335,5 +335,6 @@ void ResetAffineAnimData(void);
 u32 GetSpanPerImage(u32 shape, u32 size);
 void RequestSpriteFrameImageCopy(u16 index, u16 tileNum, const struct SpriteFrameImage *images);
 void SetSpriteOamFlipBits(struct Sprite *sprite, u8 hFlip, u8 vFlip);
+u8 LoadUniqueSpritePalette(const struct SpritePalette *palette, u16 species, u32 personality, bool8 isShiny);
 
 #endif //GUARD_SPRITE_H

--- a/include/util.h
+++ b/include/util.h
@@ -15,6 +15,7 @@ u32 CalcByteArraySum(const u8 *data, u32 length);
 void BlendPalette(u16 palOffset, u16 numEntries, u8 coeff, u32 blendColor);
 void DoBgAffineSet(struct BgAffineDstData *dest, u32 texX, u32 texY, s16 scrX, s16 scrY, s16 sx, s16 sy, u16 alpha);
 void CopySpriteTiles(u8 shape, u8 size, u8 *tiles, u16 *tilemap, u8 *output);
+void MakePaletteUnique(u16 palOffset, u16 species, u32 personality, bool8 isShiny);
 
 
 #endif // GUARD_UTIL_H

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -661,6 +661,11 @@ void BattleLoadMonSpriteGfx(struct Pokemon *mon, u32 battler)
     LoadPalette(buffer, BG_PLTT_ID(8) + BG_PLTT_ID(battler), PLTT_SIZE_4BPP);
     Free(buffer);
 
+    MakePaletteUnique(paletteOffset, species, personalityValue, IsMonShiny(mon));
+    CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
+    MakePaletteUnique(0x80 + battler * 16, species, personalityValue, IsMonShiny(mon));
+    CpuCopy32(gPlttBufferFaded + 0x80 + battler * 16, gPlttBufferUnfaded + 0x80 + battler * 16, 32);
+    
     // transform's pink color
     if (gBattleSpritesDataPtr->battlerData[battler].transformSpecies != SPECIES_NONE)
     {
@@ -980,6 +985,9 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool32 megaEvo, bo
     void *buffer = malloc_and_decompress(lzPaletteData, NULL);
     LoadPalette(buffer, paletteOffset, PLTT_SIZE_4BPP);
     Free(buffer);
+    
+    MakePaletteUnique(paletteOffset, targetSpecies, personalityValue, isShiny);
+    CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
 
     if (!megaEvo)
     {

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -357,3 +357,21 @@ bool8 LoadCompressedSpritePaletteUsingHeap(const struct CompressedSpritePalette 
     Free(buffer);
     return FALSE;
 }
+
+u32 LoadCompressedUniqueSpritePalette(const struct CompressedSpritePalette *src, u16 species, u32 personality, bool8 isShiny)
+{
+    return LoadCompressedUniqueSpritePaletteWithTag(src->data, src->tag, species, personality, isShiny);
+}
+
+u32 LoadCompressedUniqueSpritePaletteWithTag(const u32 *pal, u16 tag, u16 species, u32 personality, bool8 isShiny)
+{
+    u32 index;
+    struct SpritePalette dest;
+    void *buffer = malloc_and_decompress(pal, NULL);
+
+    dest.data = buffer;
+    dest.tag = tag;
+    index = LoadUniqueSpritePalette(&dest, species, personality, isShiny);
+    Free(buffer);
+    return index;
+}

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -448,7 +448,7 @@ static u8 EggHatchCreateMonSprite(u8 useAlt, u8 state, u8 partyId, u16 *speciesL
             HandleLoadSpecialPokePic(TRUE,
                                      gMonSpritesGfxPtr->spritesGfx[(useAlt * 2) + B_POSITION_OPPONENT_LEFT],
                                      species, pid);
-            LoadCompressedSpritePaletteWithTag(GetMonFrontSpritePal(mon), species);
+            LoadCompressedUniqueSpritePaletteWithTag(GetMonFrontSpritePal(mon), species, species, pid, IsMonShiny(mon));
             *speciesLoc = species;
         }
         break;

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -263,6 +263,8 @@ void EvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, bool8 canStopEvo, u
                         personality,
                         TRUE);
     LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(currSpecies, isShiny, personality), OBJ_PLTT_ID(1), PLTT_SIZE_4BPP);
+    MakePaletteUnique(OBJ_PLTT_ID(1), currSpecies, personality, isShiny);
+    CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(1), gPlttBufferUnfaded + OBJ_PLTT_ID(1), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(currSpecies, B_POSITION_OPPONENT_LEFT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -278,7 +280,9 @@ void EvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, bool8 canStopEvo, u
                         personality,
                         TRUE);
     LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(postEvoSpecies, isShiny, personality), OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
-
+    MakePaletteUnique(OBJ_PLTT_ID(2), postEvoSpecies, personality, isShiny);
+    CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(2), gPlttBufferUnfaded + OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
+ 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_RIGHT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
     sEvoStructPtr->postEvoSpriteId = id = CreateSprite(&gMultiuseSpriteTemplate, 120, 64, 30);
@@ -355,6 +359,8 @@ static void CB2_EvolutionSceneLoadGraphics(void)
                         personality,
                         TRUE);
     LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(postEvoSpecies, isShiny, personality), OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
+    MakePaletteUnique(OBJ_PLTT_ID(2), postEvoSpecies, personality, isShiny);
+    CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(2), gPlttBufferUnfaded + OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_RIGHT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -425,6 +431,8 @@ static void CB2_TradeEvolutionSceneLoadGraphics(void)
                                 personality,
                                 TRUE);
             LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(postEvoSpecies, isShiny, personality), OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
+            MakePaletteUnique(OBJ_PLTT_ID(2), postEvoSpecies, personality, isShiny);
+            CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(2), gPlttBufferUnfaded + OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
             gMain.state++;
         }
         break;
@@ -490,6 +498,8 @@ void TradeEvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, u8 preEvoSprit
                         TRUE);
 
     LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(postEvoSpecies, isShiny, personality), OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
+    MakePaletteUnique(OBJ_PLTT_ID(2), postEvoSpecies, personality, isShiny);
+    CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(2), gPlttBufferUnfaded + OBJ_PLTT_ID(2), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_LEFT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -35,6 +35,7 @@
 #include "text.h"
 #include "text_window.h"
 #include "trig.h"
+#include "util.h"
 #include "walda_phrase.h"
 #include "window.h"
 #include "constants/form_change_types.h"
@@ -529,6 +530,7 @@ struct PokemonStorageSystemData
     u8 ALIGNED(4) itemIconBuffer[0x800];
     u8 wallpaperBgTilemapBuffer[0x1000];
     u8 displayMenuTilemapBuffer[0x800];
+    bool8 displayMonIsShiny;
 };
 
 static u32 sItemIconGfxBuffer[98];
@@ -3980,6 +3982,7 @@ static void LoadDisplayMonGfx(u16 species, u32 pid)
         LZ77UnCompWram(sStorage->displayMonPalette, sStorage->displayMonPalBuffer);
         CpuCopy32(sStorage->tileBuffer, sStorage->displayMonTilePtr, MON_PIC_SIZE);
         LoadPalette(sStorage->displayMonPalBuffer, sStorage->displayMonPalOffset, PLTT_SIZE_4BPP);
+        MakePaletteUnique(sStorage->displayMonPalOffset, species, pid, sStorage->displayMonIsShiny);
         sStorage->displayMonSprite->invisible = FALSE;
     }
     else
@@ -6949,6 +6952,7 @@ static void SetDisplayMonData(void *pokemon, u8 mode)
             sStorage->displayMonPalette = GetMonFrontSpritePal(mon);
             gender = GetMonGender(mon);
             sStorage->displayMonItemId = GetMonData(mon, MON_DATA_HELD_ITEM);
+            sStorage->displayMonIsShiny = IsMonShiny(mon);
         }
     }
     else if (mode == MODE_BOX)
@@ -6974,6 +6978,7 @@ static void SetDisplayMonData(void *pokemon, u8 mode)
             sStorage->displayMonPalette = GetMonSpritePalFromSpeciesAndPersonality(sStorage->displayMonSpecies, isShiny, sStorage->displayMonPersonality);
             gender = GetGenderFromSpeciesAndPersonality(sStorage->displayMonSpecies, sStorage->displayMonPersonality);
             sStorage->displayMonItemId = GetBoxMonData(boxMon, MON_DATA_HELD_ITEM);
+            sStorage->displayMonIsShiny = GetBoxMonData(boxMon, MON_DATA_IS_SHINY);
         }
     }
     else

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -4406,7 +4406,7 @@ static u8 LoadMonGfxAndSprite(struct Pokemon *mon, s16 *state)
         (*state)++;
         return 0xFF;
     case 1:
-        LoadCompressedSpritePaletteWithTag(GetMonSpritePalFromSpeciesAndPersonality(summary->species2, summary->isShiny, summary->pid), summary->species2);
+        LoadCompressedUniqueSpritePaletteWithTag(GetMonSpritePalFromSpeciesAndPersonality(summary->species2, summary->isShiny, summary->pid), summary->species2, summary->species2, summary->pid, IsMonShiny(mon));
         SetMultiuseSpriteTemplateToPokemon(summary->species2, B_POSITION_OPPONENT_LEFT);
         (*state)++;
         return 0xFF;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -2,6 +2,7 @@
 #include "sprite.h"
 #include "main.h"
 #include "palette.h"
+#include "util.h"
 
 #define MAX_SPRITE_COPY_REQUESTS 64
 
@@ -1607,6 +1608,26 @@ u8 LoadSpritePaletteInSlot(const struct SpritePalette *palette, u8 paletteNum)
 void DoLoadSpritePalette(const u16 *src, u16 paletteOffset)
 {
     LoadPaletteFast(src, OBJ_PLTT_OFFSET + paletteOffset, PLTT_SIZE_4BPP);
+}
+
+#define PAL_TAG_UNIQUE_PAL 0xFFFF
+
+u8 LoadUniqueSpritePalette(const struct SpritePalette *palette, u16 species, u32 personality, bool8 isShiny)
+{
+    u8 index = IndexOfSpritePaletteTag(PAL_TAG_UNIQUE_PAL);
+
+    if (index == 0xFF)
+    {
+        return 0xFF;
+    }
+    else
+    {
+        sSpritePaletteTags[index] = palette->tag;
+        DoLoadSpritePalette(palette->data, PLTT_ID(index));
+        MakePaletteUnique(OBJ_PLTT_ID(index), species, personality, isShiny);
+        CpuCopy32(gPlttBufferFaded + OBJ_PLTT_ID(index), gPlttBufferUnfaded + OBJ_PLTT_ID(index), 32);
+        return index;
+    }
 }
 
 u32 AllocSpritePalette(u16 tag)

--- a/src/trade.c
+++ b/src/trade.c
@@ -2790,7 +2790,7 @@ static void LoadTradeMonPic(u8 whichParty, u8 state)
 
         HandleLoadSpecialPokePic(TRUE, gMonSpritesGfxPtr->spritesGfx[whichParty * 2 + B_POSITION_OPPONENT_LEFT], species, personality);
 
-        LoadCompressedSpritePaletteWithTag(GetMonFrontSpritePal(mon), species);
+        LoadCompressedUniqueSpritePaletteWithTag(GetMonFrontSpritePal(mon), species, species, personality, IsMonShiny(mon));
         sTradeAnim->monSpecies[whichParty] = species;
         sTradeAnim->monPersonalities[whichParty] = personality;
         break;

--- a/src/util.c
+++ b/src/util.c
@@ -242,3 +242,275 @@ void BlendPalette(u16 palOffset, u16 numEntries, u8 coeff, u32 blendColor)
                                       b + (((data2->b - b) * coeff) >> 4));
     }
 }
+
+#define HUE_SHIFT_NORMAL_RANGE 40
+#define HUE_SHIFT_SHINY_RANGE  30
+
+// if a mon is not in this list, the limit is zero
+static const s8 sHueShiftSpeciesLimit[NUM_SPECIES] =
+{
+    [SPECIES_CHARIZARD] = 3,
+    [SPECIES_PIKACHU] = 1,
+    [SPECIES_RAICHU] = 1,
+    [SPECIES_CLEFAIRY] = 3,
+    [SPECIES_CLEFABLE] = 3,
+    [SPECIES_VULPIX] = 3,
+    [SPECIES_NINETALES] = 3,
+    [SPECIES_JIGGLYPUFF] = 3,
+    [SPECIES_WIGGLYTUFF] = 3,
+    [SPECIES_PARAS] = 1,
+    [SPECIES_PARASECT] = -1,
+    [SPECIES_MEOWTH] = 1,
+    [SPECIES_PERSIAN] = -1,
+    [SPECIES_PSYDUCK] = 3,
+    [SPECIES_GOLDUCK] = 3,
+    [SPECIES_GROWLITHE] = 1,
+    [SPECIES_ARCANINE] = 1,
+    [SPECIES_POLIWAG] = 1,
+    [SPECIES_POLIWHIRL] = 1,
+    [SPECIES_ABRA] = -1,
+    [SPECIES_KADABRA] = -1,
+    [SPECIES_MACHOP] = 4,
+    [SPECIES_MACHOKE] = 4,
+    [SPECIES_MACHAMP] = 4,
+    [SPECIES_MAGNEMITE] = 4,
+    [SPECIES_MAGNETON] = 4,
+    [SPECIES_SEEL] = 4,
+    [SPECIES_DEWGONG] = 4,
+    [SPECIES_GRIMER] = 2,
+    [SPECIES_MUK] = 2,
+    [SPECIES_SHELLDER] = 2,
+    [SPECIES_CLOYSTER] = 2,
+    [SPECIES_GASTLY] = 4,
+    [SPECIES_HAUNTER] = 4,
+    [SPECIES_GENGAR] = 4,
+    [SPECIES_ONIX] = 4,
+    [SPECIES_RHYHORN] = 2,
+    [SPECIES_RHYDON] = 2,
+    [SPECIES_SCYTHER] = 1,
+    [SPECIES_ELECTABUZZ] = 1,
+    [SPECIES_MAGIKARP] = -1,
+    [SPECIES_LAPRAS] = -1,
+    [SPECIES_DITTO] = 4,
+    [SPECIES_EEVEE] = 3,
+    [SPECIES_FLAREON] = -1,
+    [SPECIES_AERODACTYL] = 2,
+    [SPECIES_SNORLAX] = 1,
+    [SPECIES_ZAPDOS] = 1,
+    [SPECIES_MEWTWO] = 2,
+    [SPECIES_HOOTHOOT] = -1,
+    [SPECIES_NOCTOWL] = -1,
+    [SPECIES_LEDYBA] = -1,
+    [SPECIES_LEDIAN] = -1,
+    [SPECIES_PICHU] = 1,
+    [SPECIES_TOGEPI] = 4,
+    [SPECIES_TOGETIC] = 4,
+    [SPECIES_SUNKERN] = 1,
+    [SPECIES_UMBREON] = 3,
+    [SPECIES_MURKROW] = 2,
+    [SPECIES_MISDREAVUS] = 2,
+    [SPECIES_UNOWN] = 4,
+    [SPECIES_STEELIX] = 4,
+    [SPECIES_SHUCKLE] = 3,
+    [SPECIES_SNEASEL] = 2,
+    [SPECIES_SWINUB] = 3,
+    [SPECIES_PILOSWINE] = -1,
+    [SPECIES_MANTINE] = 2,
+    [SPECIES_PHANPY] = 2,
+    [SPECIES_DONPHAN] = 2,
+    [SPECIES_SMEARGLE] = 4,
+    [SPECIES_ELEKID] = 1,
+    [SPECIES_MILTANK] = 3,
+    [SPECIES_LARVITAR] = 1,
+    [SPECIES_PUPITAR] = -1,
+    [SPECIES_LUGIA] = 4,
+    [SPECIES_POOCHYENA] = 2,
+    [SPECIES_MIGHTYENA] = 2,
+    [SPECIES_ZIGZAGOON] = 2,
+    [SPECIES_LINOONE] = 2,
+    [SPECIES_SABLEYE] = 4,
+    [SPECIES_ARON] = 4,
+    [SPECIES_LAIRON] = 4,
+    [SPECIES_AGGRON] = 4,
+    [SPECIES_SPOINK] = 2,
+    [SPECIES_GRUMPIG] = 2,
+    [SPECIES_TRAPINCH] = 3,
+    [SPECIES_CRAWDAUNT] = -1,
+    [SPECIES_FEEBAS] = 3,
+    [SPECIES_CASTFORM] = 4,
+    [SPECIES_SHUPPET] = 2,
+    [SPECIES_BANETTE] = 2,
+    [SPECIES_DUSKULL] = 2,
+    [SPECIES_DUSCLOPS] = 2,
+    [SPECIES_ABSOL] = 4,
+    [SPECIES_REGISTEEL] = 4,
+    [SPECIES_LATIAS] = -1,
+    [SPECIES_RAYQUAZA] = 3
+    // todo - add limits for any mons after gen3 that need them
+};
+
+void MakePaletteUnique(u16 palOffset, u16 species, u32 personality, bool8 isShiny)
+{
+    // System made by Citrus Bolt :')
+    u16 i, range;
+    u32 value;
+    s32 shift;
+    s8 limitMode = sHueShiftSpeciesLimit[species];
+
+    value = (personality >> 8) & 0xFFFF;
+
+    if (isShiny)
+    {
+        limitMode *= -1;
+        range = HUE_SHIFT_SHINY_RANGE;
+    }
+    else
+    {
+        range = HUE_SHIFT_NORMAL_RANGE;
+    }
+
+    if (limitMode == -1)
+        shift = (value % (range + 1)) - range;
+    else if (limitMode == 1)
+        shift = value % (range + 1);
+    else
+        shift = (value % (range * 2 + 1)) - range;
+
+    if (limitMode == 2 || limitMode == -3 || limitMode == 4 || limitMode == -4)
+    {
+        s8 dr = ((value >> 8) & 0xF) % 5;
+        s8 dg = ((value >> 4) & 0xF) % 5;
+        s8 db = (value & 0xF) % 5;
+
+        for (i = 0; i < 16; i++)
+        {
+            u16 index = i + palOffset;
+            struct PlttData *data1 = (struct PlttData *)&gPlttBufferUnfaded[index];
+            s8 r = data1->r + dr - 2;
+            s8 g = data1->g + dg - 2;
+            s8 b = data1->b + db - 2;
+
+            if (r > 31)
+                r = 31 - dr / 2;
+            if (g > 31)
+                g = 31 - dg / 2;
+            if (b > 31)
+                b = 31 - db / 2;
+            if (r < 0)
+                r = dr / 2;
+            if (g < 0)
+                g = dg / 2;
+            if (b < 0)
+                b = db / 2;
+
+            gPlttBufferFaded[index] = RGB(r, g, b);
+        }
+    }
+    else
+    {
+        for (i = 0; i < 16; i++)
+        {
+            u16 index = i + palOffset;
+            struct PlttData *data1 = (struct PlttData *)&gPlttBufferUnfaded[index];
+            s32 r = (data1->r * 1000) / 31;
+            s32 g = (data1->g * 1000) / 31;
+            s32 b = (data1->b * 1000) / 31;
+            s32 maxv, minv, d, h, s, l, o, p, q;
+
+            if (r > g)
+                maxv = r;
+            else
+                maxv = g;
+            if (b > maxv)
+                maxv = b;
+            if (r < g)
+                minv = r;
+            else
+                minv = g;
+            if (b < minv)
+                minv = b;
+
+            d = maxv - minv;
+            h = 0;
+            s = 0;
+            l = (maxv + minv) / 2;
+
+            if  (maxv != minv)
+            {
+                if (l > 500)
+                    s = 1000 * d / (2000 - maxv - minv);
+                else
+                    s = 1000 * d / (maxv + minv);
+                if (maxv == r)
+                {
+                    if (g < b)
+                        h = 1000 * (g - b) / d + 6000;
+                    else
+                        h = 1000 * (g - b) / d;
+                }
+                else if (maxv == g)
+                {
+                    h = 1000 * (b - r) / d + 2000;
+                }
+                else
+                {
+                    h = 1000 * (r - g) / d + 4000;
+                }
+                h /= 6;
+            }
+
+            h = (h + shift + 1000) % 1000;
+
+            if (s != 0)
+            {
+                o = (h + 333) % 1000;
+
+                if (l < 500)
+                    p = l * (s + 1000) / 1000;
+                else
+                    p = l + s - l * s / 1000;
+
+                q = l * 2 - p;
+
+                if (o < 167)
+                    r = q + (p - q) * o * 6 / 1000;
+                else if (o < 500)
+                    r = p;
+                else if (o < 667)
+                    r = q + (p - q) * (667 - o) * 6 / 1000;
+                else
+                    r = q;
+
+                o = h;
+
+                if (o < 167)
+                    g = q + (p - q) * o * 6 / 1000;
+                else if (o < 500)
+                    g = p;
+                else if (o < 667)
+                    g = q + (p - q) * (667 - o) * 6 / 1000;
+                else
+                    g = q;
+
+                o = (h + 1000 - 333) % 1000;
+
+                if (o < 167)
+                    b = q + (p - q) * o * 6 / 1000;
+                else if (o < 500)
+                    b = p;
+                else if (o < 667)
+                    b = q + (p - q) * (667 - o) * 6 / 1000;
+                else
+                    b = q;
+            }
+            else
+            {
+                r = l;
+                g = l;
+                b = l;
+            }
+
+            gPlttBufferFaded[index] = RGB((u8)(r * 31 / 1000), (u8)(g * 31 / 1000), (u8)(b * 31 / 1000));
+        }
+    }
+}


### PR DESCRIPTION
Implement's Citrus Bolt's mon color variation branch to shift mon palette hues based on personality. 

A few notes:
- The variation does not apply to followers or icons.
- The range of hues can differ for each species, and there are only hardcoded range limits for mons gens 1-3. Any newer mons will need to have their limits configured. They default to zero.
- I did not implement the variation for sprites in contests or the battle factory since they will not be used in Hearth.
- I tested battles, summary screen, PC, evolution, and egg hatching. I have not yet tested trading because of the involved setup.
- There's a very minor graphical glitch sometimes in the PC where a palette will flash pink for a frame while switching between certain mons. I'm not sure what causes this (or even if it was caused by these changes - haven't tried replicating without them yet) but it's pretty hard to spot unless you're looking for it.
- We'll want to make sure to add Citrus Bolt to the credits.

