### PR TITLE
Macros

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2848,3 +2848,9 @@
 	callnative RemoveFieldMugshot
 	.endm
 
+	@DebugPrintF macro
+    .macro debugprint str:req, numOrVar=65535
+    callnative ScrCmd_debugprint
+    .4byte \str
+    .2byte \numOrVar
+    .endm

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1937,6 +1937,11 @@
 	_dynmultichoice \left, \top, \ignoreBPress, \maxBeforeScroll, \shouldSort, \initialSelected, \callbacks, NULL
 	.endm
 
+	@ A simpler version of dynmultichoice that only takes arguments; meant to be a template for the player character's dialogue.
+	.macro mcdialogue argv:vararg
+	_dynmultichoice 0, 0, TRUE, 10, FALSE, 0, DYN_MULTICHOICE_CB_NONE, \argv
+	.endm
+
 @ Supplementary
 
 	.macro goto_if_unset flag:req, dest:req

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3467,3 +3467,24 @@ bool8 ScrCmd_subquestmenu(struct ScriptContext *ctx)
 
     return TRUE;
 }
+
+bool8 ScrCmd_debugprint(struct ScriptContext *ctx)
+{
+    u16 num;
+    const u8 *str = (const u8*)ScriptReadWord(ctx);
+    u16 numOrVar = ScriptReadHalfword(ctx);
+
+    if (str != NULL)
+    {
+        if (numOrVar != 65535)
+        {
+            num = VarGet(numOrVar);
+            DebugPrintfLevel(MGBA_LOG_WARN, "%S, %u", str, num);
+        }
+        else
+        {
+            DebugPrintfLevel(MGBA_LOG_WARN, "%S", str);
+        }
+    }
+    return FALSE;
+}


### PR DESCRIPTION
Macro 1: debugprint
Allows for easy debug printing in scripts.

Macro 2: mcdialogue
A macro using the _dynmultichoice macro in order to use the template of MC dialogue, so only declaring the args is needed.
