### PR TITLE
fix: down_arrow shows up after a few setspeakers

### DIFF
--- a/include/string_util.h
+++ b/include/string_util.h
@@ -5,7 +5,6 @@ extern u8 gStringVar1[0x100];
 extern u8 gStringVar2[0x100];
 extern u8 gStringVar3[0x100];
 extern u8 gStringVar4[0x3E8];
-extern u8 gNamePlateBuffer[0x20];
 
 enum StringConvertMode
 {

--- a/src/field_name_box.c
+++ b/src/field_name_box.c
@@ -29,6 +29,7 @@ static void WindowFunc_ClearNamebox(u8, u8, u8, u8, u8, u8);
 void TrySpawnNamebox(u32 tileNum)
 {
     u8 *strbuf = AllocZeroed(32 * sizeof(u8));
+
     if ((OW_FLAG_SUPPRESS_NAME_BOX != 0 && FlagGet(OW_FLAG_SUPPRESS_NAME_BOX)) || gSpeakerName == NULL || !strbuf)
     {
         // Re-check again in case anything but !strbuf is TRUE.
@@ -83,7 +84,6 @@ void TrySpawnNamebox(u32 tileNum)
     }
 
     SaveTextColors(&bakColors[0], &bakColors[1], &bakColors[2]);
-    AddTextPrinterParameterized2(1, FONT_SMALL, gNamePlateBuffer, 0, NULL, 11, 0, 10);
     AddTextPrinterParameterized3(sNameboxWindowId, fontId, strX, 0, colors, 0, strbuf);
     RestoreTextColors(&bakColors[0], &bakColors[1], &bakColors[2]);
     PutWindowTilemap(sNameboxWindowId);

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -13,7 +13,6 @@ EWRAM_DATA u8 gStringVar2[0x100] = {0};
 EWRAM_DATA u8 gStringVar3[0x100] = {0};
 EWRAM_DATA u8 gStringVar4[0x3E8] = {0};
 EWRAM_DATA static u8 sUnknownStringVar[16] = {0};
-EWRAM_DATA u8 gNamePlateBuffer[0x20] = {0};
 
 static const u8 sDigits[] = __("0123456789ABCDEF");
 


### PR DESCRIPTION
shouldn't have kept the `gNameBoxBuffer` smh.
also coincidentally fixes the `{SPEAKER}` inline macro crashing, so use it more when possible :3

## Discord contact info
mudskipper13